### PR TITLE
Update GitHub links to the v2 repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Example
 
 Running: ``awslogs get /var/logs/syslog ALL -s1d`` will return you events from any ``stream`` in the ``/var/logs/syslog`` group generated in the last day.
 
-.. image:: https://github.com/jorgebastida/awslogs/raw/master/media/screenshot.png
+.. image:: https://github.com/sidpremkumar/awslogs-v2/blob/master/media/screenshot.png?raw=true
 
 
 Installation

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -203,7 +203,7 @@ def main(argv=None):
         options['aws_profile'] = 'SENSITIVE'
         sys.stderr.write("\n")
         sys.stderr.write("\nYou've found a bug! Please, raise an issue attaching the following traceback\n")
-        sys.stderr.write("https://github.com/jorgebastida/awslogs/issues/new\n")
+        sys.stderr.write("https://github.com/sidpremkumar/awslogs-v2/issues/new\n")
         sys.stderr.write("\n")
 
         issue_info = "\n".join((

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
 setup(
     name='awslogs',
     version='0.15.0',
-    url='https://github.com/jorgebastida/awslogs',
+    url='https://github.com/sidpremkumar/awslogs-v2',
     license='BSD',
     author='Jorge Bastida',
     author_email='me@jorgebastida.com',


### PR DESCRIPTION
Can you please enable GitHub issues for this repo as well? Assuming you're still intending to keep this v2 repo as the latest and most-maintained version 